### PR TITLE
Handle missing columns in passing data

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -38,7 +38,11 @@ def load_data(year, category):
         raw = df.drop(df[df.Age == 'Age'].index) # Deletes repeating headers in content
         raw = raw.fillna(0)
         playerstats = raw.drop(['Rk'], axis=1)
-        playerstats = playerstats.drop(['Yds.1', 'QBrec', 'TD%', 'Int%', 'AY/A', 'Sk%', 'NY/A', 'ANY/A', '4QC', 'GWD'], axis=1)
+        # Some seasons don't include all passing metrics. Drop the extras if they
+        # exist so older datasets load without raising a ``KeyError``.
+        columns_to_drop = ['Yds.1', 'QBrec', 'TD%', 'Int%', 'AY/A', 'Sk%',
+                           'NY/A', 'ANY/A', '4QC', 'GWD']
+        playerstats = playerstats.drop(columns=columns_to_drop, errors='ignore')
         if year > 2005:
             columns_to_convert = ['Age', 'G', 'GS', 'Cmp', 'Att', 'Cmp%', 'Yds', 'TD', 'Int', 'Lng', 'Y/A', 'Y/G', 'Rate', 'QBR']
         else:


### PR DESCRIPTION
## Summary
- Avoid KeyError when older passing datasets lack certain advanced metrics

## Testing
- `python -m py_compile app.py utils.py`
- `python - <<'PY'
import pandas as pd
import utils
cols = ['Player', 'Age', 'G', 'GS', 'Cmp', 'Att', 'Cmp%', 'Yds', 'TD', 'Int', 'Lng', 'Y/A', 'Y/G', 'Rate']
example = pd.DataFrame([{c:1 for c in cols}])
playerstats = example.drop(columns=['Yds.1', 'QBrec', 'TD%', 'Int%', 'AY/A', 'Sk%', 'NY/A', 'ANY/A', '4QC', 'GWD'], errors='ignore')
print('After drop columns', playerstats.columns.tolist())
PY`


------
https://chatgpt.com/codex/tasks/task_e_689c95c613a8832f85f851f212a7195d